### PR TITLE
chore: drop `do` keyword

### DIFF
--- a/flix.sty
+++ b/flix.sty
@@ -49,7 +49,6 @@
     def,
     deref,
     discard,
-    do,
     eff,
     else,
     enum,


### PR DESCRIPTION
Related to flix/flix#8926