### PR TITLE
feat: update keywords

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -1,6 +1,5 @@
 \documentclass{article}
 
-\usepackage[T1]{fontenc}
 \usepackage{inconsolata}
 \usepackage{microtype}
 

--- a/example.tex
+++ b/example.tex
@@ -1,5 +1,6 @@
 \documentclass{article}
 
+\usepackage[T1]{fontenc}
 \usepackage{inconsolata}
 \usepackage{microtype}
 
@@ -85,7 +86,7 @@ type alias Day = Int32
 enum Date(Year, Month, Day) with Eq, Order
 
 /// We implement our own instance of ToString for Date
-/// since we don't want the default "Date(1948, December, 10)"
+/// since we don't want the default `Date(1948, December, 10)`
 instance ToString[Date] {
     pub def toString(x: Date): String =
         let Date.Date(y, m, d) = x;
@@ -103,4 +104,67 @@ def printDate(d: Date): Unit \ IO =
     println(message)
 \end{lstlisting}
 
+\section{Collection Literals}
+
+\begin{lstlisting}
+/// Flix has built-in literal syntax for the standard collections.
+def literals(): (List[Int32], Set[Int32], Map[String, Int32], Vector[Int32], Array[Int32, Static]) =
+    let xs  = List#{1, 2, 3};
+    let ys  = Set#{1, 2, 3};
+    let env = Map#{"min" => 0, "max" => 100};
+    let zs  = Vector#{10, 20, 30};
+    let arr = Array#{1, 2, 3} @ Static;
+    (xs, ys, env, zs, arr)
+\end{lstlisting}
+
+\section{Restrictable Variants and Provenance}
+
+\begin{lstlisting}
+restrictable enum Color[s] {
+    case Red
+    case Blue
+    case Green
+}
+
+/// xvar constructs extensible variants and ematch deconstructs them.
+def describeColor(): String =
+    let tag = xvar Color.Red;
+    ematch tag {
+        case Color.Red   => "red"
+        case Color.Blue  => "blue"
+        case Color.Green => "green"
+    }
+
+/// psolve computes a provenance model and pquery extracts one explanation.
+def cycleWitness(): Vector[String] =
+    let db = #{
+        Edge(1, 2). Edge(2, 3). Edge(3, 1).
+    };
+    let rules = #{
+        Path(x, y) :- Edge(x, y).
+        Path(x, z) :- Path(x, y), Edge(y, z).
+        Cycle(x)   :- Path(x, x).
+    };
+    let pm = psolve db, rules;
+    pquery pm select Cycle(1) with {Edge} |>
+        Vector.map(v -> ematch v { case Edge(x, y) => "${x} -> ${y}" })
+\end{lstlisting}
+
+\section{Objects and Super Calls}
+
+\begin{lstlisting}
+import java.lang.Object
+
+/// Super calls are available inside object literals.
+def mkWrappedObject(): Object \ IO =
+    new Object {
+        def toString(_this: Object): String \ IO =
+            "wrapped:" + super.toString()
+
+        def hashCode(_this: Object): Int32 \ IO =
+            super.hashCode() + 1
+    }
+\end{lstlisting}
+
 \end{document}
+

--- a/example.tex
+++ b/example.tex
@@ -166,5 +166,70 @@ def mkWrappedObject(): Object \ IO =
     }
 \end{lstlisting}
 
-\end{document}
+\section{Effect Handler}
 
+\begin{lstlisting}
+def main(): Unit \ { Clock, Http, Logger, IO } =
+    let defaultHeaders = Map#{
+        "Accept"        => List#{"application/json"},
+        "Authorization" => List#{"Bearer tok123"}
+    };
+    run {
+        let urls = List#{"/api/users", "/api/posts"};
+        foreach (url <- urls) {
+            match Http.get(url) {
+                case Ok(resp) => println("${url} -> ${HttpResponse.status(resp)}")
+                case Err(err) => println("${url} -> ${err}")
+            }
+        };
+        match Http.get("https://notfound.flix.dev/") {
+            case Ok(resp) => println("notfound -> ${HttpResponse.status(resp)}")
+            case Err(err) => println("notfound -> ${err}")
+        }
+    } with Http.withBaseUrl("https://flix.dev")
+      with Http.withDefaultHeaders(defaultHeaders)
+      with Http.withRetry(Retry.linear(maxRetries = 2, delay = milliseconds(100)))
+      with Http.withCircuitBreaker(failureThreshold = 3, cooldown = seconds(5))
+      with Http.withSlidingWindow(maxRequests = 2, window = seconds(1))
+      with Http.withLogging
+\end{lstlisting}
+
+\section{Structs and Regions}
+
+\begin{lstlisting}
+/// A mutable struct that represents a person
+struct Person[r] {
+    name: String,
+    mut age: Int32,
+    mut height: Int32
+}
+
+mod Person {
+    /// Create a new `Person` struct with the specified name
+    pub def giveBirth(name: String, rc: Region[r]): Person[r] \ r =
+        new Person @ rc { name = name, age = 0, height = 30 }
+
+    /// Increase the age of `person` by 1 and if the age is less than 18,
+    /// increase their height by 10.
+    pub def birthday(person: Person[r]): Unit \ r =
+        person->age = person->age + 1;
+        if (person->age < 18) {
+            person->height = person->height + 10
+        } else {
+            ()
+        }
+
+    pub def printPerson(person: Person[r]): Unit \ {IO, r} =
+        println("${person->name} is ${person->age} years old and is ${person->height} cm tall")
+}
+
+def main(): Unit \ IO = region rc {
+    let joe = Person.giveBirth("Joe", rc);
+    Person.birthday(joe);
+    Person.birthday(joe);
+    Person.birthday(joe);
+    Person.printPerson(joe)
+}
+\end{lstlisting}
+
+\end{document}

--- a/flix.sty
+++ b/flix.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
-\ProvidesPackage{flix}[2021/11/24 Flix]
+\ProvidesPackage{flix}[2026/04/24 Flix]
 
 \RequirePackage{listings}
 \RequirePackage{xcolor}
@@ -18,6 +18,7 @@
   commentstyle      = \color{comment-color},
   identifierstyle   = \color{black},
   stringstyle       = \color{string-color},
+  sensitive         = true,
   emph              = [1]{Unit, Bool, Char, Float32, Float64, Int8, Int16, Int32, Int64, String},
   emphstyle         = [1]{\color{type-color}},
   showspaces        = false,
@@ -30,6 +31,7 @@
   morestring        = [b]",
   morestring        = [b]',
   morestring        = [b]""",
+  otherkeywords     = {Array\#, List\#, Map\#, Set\#, Vector\#, choose*},
   morekeywords      = {
     alias,
     and,
@@ -39,14 +41,11 @@
     checked_cast,
     checked_ecast,
     choose,
-    choose*,
-    dbg,
-    dbg!,
-    dbg!!,
     def,
     discard,
     eff,
     else,
+    ematch,
     enum,
     false,
     fix,
@@ -78,7 +77,9 @@
     or,
     override,
     par,
+    pquery,
     project,
+    psolve,
     pub,
     query,
     redef,
@@ -96,21 +97,20 @@
     static,
     Static,
     struct,
+    super,
     throw,
     trait,
     true,
     try,
     type,
-    typematch,
     unchecked_cast,
     Univ,
     unsafe,
-    unsafely,
     use,
     where,
     with,
-    without,
     xor,
+    xvar,
     yield
   },
 }

--- a/flix.sty
+++ b/flix.sty
@@ -18,7 +18,6 @@
   commentstyle      = \color{comment-color},
   identifierstyle   = \color{black},
   stringstyle       = \color{string-color},
-  sensitive         = true,
   emph              = [1]{Unit, Bool, Char, Float32, Float64, Int8, Int16, Int32, Int64, String},
   emphstyle         = [1]{\color{type-color}},
   showspaces        = false,
@@ -31,7 +30,6 @@
   morestring        = [b]",
   morestring        = [b]',
   morestring        = [b]""",
-  otherkeywords     = {Array\#, List\#, Map\#, Set\#, Vector\#, choose*},
   morekeywords      = {
     alias,
     and,


### PR DESCRIPTION
Let the codex update the keywords:

```
What changed:
  - Added non-identifier keywords via otherkeywords: Array#, List#, Map#, Set#, Vector#, choose*.
  - Removed stale entries not present in the lexer anymore: dbg, dbg!, dbg!!, typematch, unsafely, without.
  - Set sensitive = true explicitly
  - Bumped the package date to 2026/04/24.
``` 

 Also, the codex has added some examples.
 
```
- A Collection Literals section covering List#, Set#, Map#, Vector#, and Array# at example.tex:107.
  - A Restrictable Variants and Provenance section covering choose*, xvar, ematch, psolve, and pquery at example.tex:120.
  - An Objects and Super Calls section showing super.toString() and super.hashCode() inside an object literal at example.tex:160.
```